### PR TITLE
change cluster from "example" to ""

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -1,5 +1,5 @@
 ---
-cluster: "example"
+cluster: ""
 form:
   - bc_account
   - bc_queue


### PR DESCRIPTION
change cluster from example, which causes errors in 1.8+ to an empty string which will correctly raise an error